### PR TITLE
fix: 修复SQL解析功能中数字0被错误转换为字符串的问题

### DIFF
--- a/src/views/commands/parse-sql.vue
+++ b/src/views/commands/parse-sql.vue
@@ -305,7 +305,7 @@ const parseParamByType = (p: any | undefined): string => {
       return p
     }
     let obj = parseObj(param)
-    if (obj && isNumber(obj)) {
+    if (obj !== null && obj !== undefined && isNumber(obj)) {
       return obj.toString()
     }
     return `'${escapeQuotMarks(param)}'`


### PR DESCRIPTION
- 修复parseParamByType函数中falsy值判断错误，避免数字0被误判
- 确保LIMIT分页参数中的数字0正确显示为数字而非字符串
- 解决通用SQL日志解析中所有数字0被加引号的问题

测试验证：
- WHERE条件中的数字0: status = 0 ✓
- LIMIT分页参数: LIMIT 0, 10 ✓
- INSERT/UPDATE语句中的数字0正确处理 ✓
- 其他数字类型和字符串参数保持正常 ✓